### PR TITLE
fixes for homepage, license and pkgconfigs

### DIFF
--- a/llvm-roc/package.yml
+++ b/llvm-roc/package.yml
@@ -3,7 +3,8 @@ version    : 3.1.0
 release    : 1
 source     :
     - https://github.com/RadeonOpenCompute/llvm-project/archive/roc-ocl-3.1.0.tar.gz : fb62584b8db54483e40e3c6ec35da700455b7e9bce5ce152a1382243a064c387
-license    : Apache
+homepage   : https://github.com/RadeonOpenCompute/llvm-project
+license    : Apache-2.0
 component  : programming.devel
 summary    : ROCm llvm component
 description: |

--- a/rocm-cmake/package.yml
+++ b/rocm-cmake/package.yml
@@ -5,7 +5,7 @@ source     :
     - https://github.com/RadeonOpenCompute/rocm-cmake/archive/roc-3.0.0.tar.gz : 9393fd534a100e8da55f44d0625337d76f3c7890e0297fe690c9e7d384b205ef
 license    : MIT
 component  : programming.devel
-summary    : ROCM cmake modules provides cmake modules for common build tasks needed for the ROCM software stack.
+summary    : Rocm cmake modules
 description: |
      ROCM cmake modules provides cmake modules for common build tasks needed for the ROCM software stack.
 setup      : |
@@ -17,12 +17,12 @@ build      : |
     cmake --build . --target install
 install    : |
     cd build/share/rocm/cmake/
-    install -D -m 00644 ROCMAnalyzers.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMAnalyzers.cmake
-    install -D -m 00644 ROCMClangTidy.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMClangTidy.cmake
-    install -D -m 00644 ROCMConfig.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMConfig.cmake
-    install -D -m 00644 ROCMCppCheck.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMCppCheck.cmake
-    install -D -m 00644 ROCMCreatePackage.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMCreatePackage.cmake
-    install -D -m 00644 ROCMInstallSymlinks.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMInstallSymlinks.cmake
-    install -D -m 00644 ROCMInstallTargets.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMInstallTargets.cmake
-    install -D -m 00644 ROCMPackageConfigHelpers.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMPackageConfigHelpers.cmake
-    install -D -m 00644 ROCMSetupVersion.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMSetupVersion.cmake
+    install -Dm00644 ROCMAnalyzers.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMAnalyzers.cmake
+    install -Dm00644 ROCMClangTidy.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMClangTidy.cmake
+    install -Dm00644 ROCMConfig.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMConfig.cmake
+    install -Dm00644 ROCMCppCheck.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMCppCheck.cmake
+    install -Dm00644 ROCMCreatePackage.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMCreatePackage.cmake
+    install -Dm00644 ROCMInstallSymlinks.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMInstallSymlinks.cmake
+    install -Dm00644 ROCMInstallTargets.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMInstallTargets.cmake
+    install -Dm00644 ROCMPackageConfigHelpers.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMPackageConfigHelpers.cmake
+    install -Dm00644 ROCMSetupVersion.cmake $installdir/usr/share/cmake-3.16/Modules/ROCMSetupVersion.cmake

--- a/rocm-comgr/package.yml
+++ b/rocm-comgr/package.yml
@@ -3,7 +3,8 @@ version    : 3.1.0
 release    : 1
 source     :
     - https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/archive/roc-3.1.0.tar.gz : d490dc3a552f0b430b3bf4f978f5765b65b580977340293c1e2003c2cee69e9a
-license    : NCSA Open Source License
+homepage   : https://github.com/RadeonOpenCompute/ROCm-CompilerSupport
+license    : NCSA
 component  : programming.devel
 summary    : The compiler support repository provides various Lightning Compiler related services. It currently contains one library, the Code Object Manager (Comgr).
 description: |

--- a/rocm-device-libs/package.yml
+++ b/rocm-device-libs/package.yml
@@ -3,7 +3,8 @@ version    : 3.1.0
 release    : 1
 source     :
     - https://github.com/RadeonOpenCompute/ROCm-Device-Libs/archive/roc-ocl-3.1.0.tar.gz : bce5da4adba4ea360cd4a8aff39d25d0d8a900bdd13aff0482b685bb495508f6
-license    : NCSA Open Source License
+homepage   : https://github.com/RadeonOpenCompute/ROCm-Device-Libs
+license    : NCSA
 component  : programming.devel
 summary    : AMD specific device-side language runtime libraries.
 description: |

--- a/rocm-opencl-runtime/package.yml
+++ b/rocm-opencl-runtime/package.yml
@@ -2,27 +2,28 @@ name       : rocm-opencl-runtime
 version    : 3.1.0
 release    : 1
 source     :
-    -  https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/archive/roc-3.1.0.tar.gz : c14f544daef32e991af4f356825d1e9cb99ddad4a58ba7dda6054603a9c5d1b8
+    - https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/archive/roc-3.1.0.tar.gz : c14f544daef32e991af4f356825d1e9cb99ddad4a58ba7dda6054603a9c5d1b8
     - https://github.com/KhronosGroup/OpenCL-ICD-Loader/archive/6c03f8b58fafd9dd693eaac826749a5cfad515f8.tar.gz : c94d5bb6dc980c4d41d73e2b81663a19aabe494e923e2d0eec72a4c95b318438
-license    : MIT
+homepage   : https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime
+license    :
+    - Apache-2.0
+    - MIT
 component  : programming.devel
-summary    :  OpenCL 2.0 compatible language runtime
+summary    : OpenCL 2.0 compatible language runtime
 description: |
      OpenCL 2.0 compatible language runtime
 patterns   :
     - /*
 extract    : False
 builddeps  :
+    - pkgconfig(OpenCL)
+    - pkgconfig(gl)
+    - pkgconfig(libhsakmt)
     - rocm-cmake
     - rocr-runtime-devel
-    - roct-thunk-interface-devel
     - rocm-comgr-devel
     - rocm-device-libs-devel
     - llvm-roc
-    - ocl-icd-devel
-    - mesalib-devel
-rundeps    :
-    
 setup      : |
     tar -xvzf $sources/roc-3.1.0.tar.gz -C ./ --strip-components=1
     mkdir api/opencl/khronos/icd

--- a/rocminfo/package.yml
+++ b/rocminfo/package.yml
@@ -3,7 +3,8 @@ version    : 3.1.0
 release    : 1
 source     :
     - https://github.com/RadeonOpenCompute/rocminfo/archive/roc-3.1.0.tar.gz : f024fef05e5ea5bc7316d4bddb5562cbac7048183c351cdb8afd4156ff4c049c
-license    : Open Source License (NCSA)
+homepage   : https://github.com/RadeonOpenCompute/rocminfo/
+license    : NCSA
 component  : programming.devel
 summary    : ROCm Application for Reporting System Info
 description: |

--- a/rocr-runtime/package.yml
+++ b/rocr-runtime/package.yml
@@ -3,16 +3,15 @@ version    : 3.1.0
 release    : 1
 source     :
     - https://github.com/RadeonOpenCompute/ROCR-Runtime/archive/roc-3.1.0.tar.gz : b162464ef87ce39518e59ef8406d6b897aa7a930795c586829614ed87aa1c2ce
+homepage   : https://github.com/RadeonOpenCompute/ROCR-Runtime
 license    : NCSA
 component  : programming.devel
-summary    : This repository includes the user-mode API interfaces and libraries necessary for host applications to launch compute kernels to available HSA ROCm kernel agents.
+summary    : HSA Runtime API and runtime for ROCm
 description: |
     This repository includes the user-mode API interfaces and libraries necessary for host applications to launch compute kernels to available HSA ROCm kernel agents.
 builddeps  :
     - pkgconfig(libelf)
-    - roct-thunk-interface-devel
-rundeps    :
-    - roct-thunk-interface
+    - pkgconfig(libhsakmt)
 setup      : |
     mkdir -p build
     cd build

--- a/roct-thunk-interface/package.yml
+++ b/roct-thunk-interface/package.yml
@@ -3,17 +3,15 @@ version    : 3.1.0
 release    : 1
 source     : 
     - https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/archive/roc-3.1.0.tar.gz : b08176b5f4af39d0160990f9f1dea5d27974f9282f544140b4a41d19446fe570
+homepage   : https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface
 license    : MIT
 component  : programming.devel
-summary    : This repository includes the user-mode API interfaces used to interact with the ROCk driver. Currently supported agents include only the AMD/ATI Fiji family of discrete GPUs.
+summary    : Radeon Open Compute Thunk Interface 
 description: |
     This repository includes the user-mode API interfaces used to interact with the ROCk driver. Currently supported agents include only the AMD/ATI Fiji family of discrete GPUs.
 builddeps  :
     - pkgconfig(libpci)
     - pkgconfig(numa)
-rundeps    :
-    - numactl
-    - pciutils
 setup      : |
     mkdir -p build/
     cd build
@@ -23,7 +21,7 @@ build      : |
     %make
     %make build-dev
 install    : |
-   cd build
-   %make_install
-   %make DESTDIR=$installdir install-dev
+    cd build
+    %make_install
+    %make DESTDIR=$installdir install-dev
 


### PR DESCRIPTION
Made some changes that actually don't affect the build process.
- Added homepages
- Used [SPDX Licenses](https://spdx.org/licenses/)
- Use shorter summaries. There is no point using same summary with descriptions.
- use pkgconfigs instead of -devel packages
  - `pkgconfig(gl)` for `mesalib-devel`
  - `pkgconfig(OpenCL)` for `ocl-icd-devel`
  - `pkgconfig(libhsakmt)` for `roct-thunk-interface-devel`
- remove not needed rundeps since they are pulled by pkgconfigs.
- `-D -m 00644` should be `-Dm00644`