### PR TITLE
package.yml fixes in roct-thunk-interface

### DIFF
--- a/roct-thunk-interface/package.yml
+++ b/roct-thunk-interface/package.yml
@@ -4,7 +4,9 @@ release    : 1
 source     : 
     - https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/archive/roc-3.1.0.tar.gz : b08176b5f4af39d0160990f9f1dea5d27974f9282f544140b4a41d19446fe570
 homepage   : https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface
-license    : MIT
+license    : 
+    - BSD-2-Clause
+    - MIT
 component  : programming.devel
 summary    : Radeon Open Compute Thunk Interface 
 description: |
@@ -18,10 +20,9 @@ setup      : |
     %cmake -DCMAKE_BUILD_TYPE=Release ..
 build      : |
     cd build
-    %make
     %make build-dev
 install    : |
     cd build
-    %make_install
-    %make DESTDIR=$installdir install-dev
+    %make_install DESTDIR=$installdir install-dev
+    rm -rf $installdir//usr/share/doc
 

--- a/roct-thunk-interface/package.yml
+++ b/roct-thunk-interface/package.yml
@@ -23,6 +23,5 @@ build      : |
     %make build-dev
 install    : |
     cd build
-    %make_install DESTDIR=$installdir install-dev
+    %make_install install-dev
     rm -rf $installdir/usr/share/doc
-

--- a/roct-thunk-interface/package.yml
+++ b/roct-thunk-interface/package.yml
@@ -15,7 +15,7 @@ builddeps  :
     - pkgconfig(libpci)
     - pkgconfig(numa)
 setup      : |
-    mkdir -p build/
+    mkdir -p build
     cd build
     %cmake -DCMAKE_BUILD_TYPE=Release ..
 build      : |
@@ -24,5 +24,5 @@ build      : |
 install    : |
     cd build
     %make_install DESTDIR=$installdir install-dev
-    rm -rf $installdir//usr/share/doc
+    rm -rf $installdir/usr/share/doc
 


### PR DESCRIPTION
Some little changes:
- Remove extra /
- Remove `/usr/share/doc` wich was containing only `License.md` file. Licenses are specified in License section of `package.yml` no need to make a copy of them inside the package.
- Remove extra `%make` `%make_install` is enough. 